### PR TITLE
Fix for back navigation after redirect

### DIFF
--- a/frontend/src/components/general/GoBackButton.test.tsx
+++ b/frontend/src/components/general/GoBackButton.test.tsx
@@ -25,6 +25,10 @@ function setReferrer(referrer: string) {
   jest.spyOn(document, "referrer", "get").mockReturnValue(referrer);
 }
 
+function setHistoryLength(length: number) {
+  jest.spyOn(window.history, "length", "get").mockReturnValue(length);
+}
+
 function renderButton(props: any = {}) {
   const merged = {
     texts: baseTexts,
@@ -58,10 +62,24 @@ describe("GoBackButton", () => {
 
   it("navigates back in history when the referrer is internal", () => {
     setReferrer("http://localhost/en/browse");
+    setHistoryLength(2);
     renderButton();
     fireEvent.click(screen.getByText("Go back"));
     expect(mockBack).toHaveBeenCalledTimes(1);
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the browse page when arrived via redirect (referrer is redirect source, history.length is 1)", () => {
+    // Server-side redirects (e.g. /klimakuechen-erlangen → /de/projects/klimakuechen)
+    // cause the browser to set document.referrer to the redirect source URL (same
+    // host). With history.length === 1 (the 301 source was not added to history),
+    // router.back() would do nothing, so we must fall back to the default URL.
+    setReferrer("http://localhost/klimakuechen-erlangen");
+    setHistoryLength(1);
+    renderButton({ locale: "en" });
+    fireEvent.click(screen.getByText("Go back"));
+    expect(mockBack).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/en/browse");
   });
 
   it("falls back to the browse page when there is no referrer", () => {
@@ -107,6 +125,7 @@ describe("GoBackButton", () => {
 
   it("navigates back from the tiny screen button", () => {
     setReferrer("http://localhost/en/browse");
+    setHistoryLength(2);
     renderButton({ tinyScreen: true });
     fireEvent.click(screen.getByRole("button"));
     expect(mockBack).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/general/GoBackButton.tsx
+++ b/frontend/src/components/general/GoBackButton.tsx
@@ -100,12 +100,21 @@ export default function GoBackButton({
 
     // Priority 2: Go back to the page the user actually came from, acting like
     // the browser back button. Only do so when the referrer indicates an
-    // internal page. If the user came from an external site, opened the page
-    // via "open in new tab" on an external link, or typed the URL directly,
-    // the referrer will be empty or on a different host — in those cases
-    // history.back() would either do nothing (new tab) or take the user back
-    // to the external site, so we fall back to a hard-coded internal URL.
-    if (typeof document !== "undefined" && isInternalReferrer(document.referrer)) {
+    // internal page AND there is actual history to go back to.
+    //
+    // When the user arrives via a server-side redirect (e.g. a vanity URL like
+    // /klimakuechen-erlangen → /de/projects/klimakuechen), the Fetch spec sets
+    // document.referrer to the redirect source URL (same host), which makes
+    // isInternalReferrer return true. However, for permanent (301) redirects
+    // the browser does not add the source to the history stack, so
+    // router.back() with history.length === 1 would silently do nothing.
+    // Checking history.length > 1 prevents this silent no-op.
+    const hasBackHistory = typeof window !== "undefined" && window.history.length > 1;
+    if (
+      hasBackHistory &&
+      typeof document !== "undefined" &&
+      isInternalReferrer(document.referrer)
+    ) {
       router.back();
     } else {
       router.push(getDefaultBackUrl());


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme

## What and Why

Fixes the 1st issue of #2227
