### PR TITLE
improve calendar picker day alignment

### DIFF
--- a/frontend/src/components/eventCalendar/EventCalendarContent.tsx
+++ b/frontend/src/components/eventCalendar/EventCalendarContent.tsx
@@ -121,7 +121,9 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "column",
     alignItems: "center",
     justifyContent: "center",
-    width: "100%",
+    flex: "1 1 0",
+    minWidth: 0,
+    overflow: "hidden",
   },
   eventDot: {
     width: 5,


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme

## What and Why

Just a small styling fix, no ticket.