### PR TITLE
Add Hitzefrei redirect

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -104,6 +104,11 @@ module.exports = withBundleAnalyzer({
         permanent: true,
       },
       {
+        source: "/hitzefrei",
+        destination: "/de/projects/wurzburg-entsiegeln?hub=wuerzburg",
+        permanent: true,
+      },
+      {
         source: "/hubs/prio1",
         destination: "/hubs/prio1/browse",
         permanent: false,


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme

## What and Why

Just adding a small redirect, no functional changes in the platform
