### PR TITLE
Optimize release packaging.

### DIFF
--- a/.github/workflows/master_climate-backend-appservice(slot2).yml
+++ b/.github/workflows/master_climate-backend-appservice(slot2).yml
@@ -46,7 +46,7 @@ jobs:
         run: echo '{"sha":"${{ github.sha }}","ref":"${{ github.ref_name }}","built_at":"${{ github.event.head_commit.timestamp }}"}' > backend/build_info.json
 
       - name: Zip artifact for deployment
-        run: zip release.zip ./* -r
+        run: zip -r release.zip backend/
 
       - name: Upload artifact for deployment jobs
         uses: actions/upload-artifact@v7

--- a/.github/workflows/master_climateconnect-frontend-appservice(slot2).yml
+++ b/.github/workflows/master_climateconnect-frontend-appservice(slot2).yml
@@ -93,7 +93,7 @@ jobs:
           }' > frontend/build_info.json
 
       - name: Zip artifact for deployment
-        run: zip release.zip ./* -r
+        run: zip -r release.zip frontend/
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v7

--- a/backend/start_backend.sh
+++ b/backend/start_backend.sh
@@ -1,0 +1,25 @@
+
+# Install spatial dependencies
+apt-get update -qq && apt-get install binutils libproj-dev gdal-bin -yqq
+
+# Install pdm
+pip install pdm
+
+# install dependencies
+pdm install
+
+# activate venv
+$(pdm venv activate)
+
+# Start server
+gunicorn --preload --bind=0.0.0.0 climateconnect_main.asgi:application -w 4 -k uvicorn.workers.UvicornWorker &
+
+# Worker for the `lookup` queue. CELERY_TASK_ROUTES routes
+# location.tasks.fetch_autocomplete there, so without this worker nothing
+# consumes location autocomplete jobs and every lookup falls back to the
+# slow inline path in LocationAutocompleteView.
+celery -A climateconnect_main worker -Q lookup -c 4 -l INFO &
+
+# Default worker (+ embedded beat). Stays in the foreground so the container
+# lives and dies with it, as before.
+celery -A climateconnect_main worker -B -l INFO


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme

## What and Why
Optimizes the frontend and backend deployment. 

## Problem Statement

Both the frontend and backend production deployment workflows zip and deploy the **entire repository root** to their respective Azure App Services:

```yaml
# Both workflows contain this line:
- name: Zip artifact for deployment
  run: zip release.zip ./* -r   # ← runs from repo root, zips everything
```

This has several problems:

### Frontend workflow deploys backend code to the frontend server
The frontend App Service receives `backend/` Python source, `backend/.backend_env`, `doc/` specs, `.github/` workflows, and the entire monorepo. The frontend server only needs the compiled Next.js output and its runtime dependencies.

### Backend workflow deploys frontend code to the backend server
The backend App Service receives `frontend/` (including `node_modules/`), `doc/`, `.github/`, and the entire monorepo. The backend server only needs the Django Python application.

### Shared problems
1. **Unnecessarily large artifacts**: the full monorepo is zipped and uploaded, slowing deployments and wasting Azure storage.
2. **Deployment noise**: each App Service's file system contains files it will never use. Slowing down the deployment and not being efficient. 
