### PR TITLE
Fix add to google calendar button

### DIFF
--- a/frontend/src/components/eventCalendar/SubscribeToCalendarButton.tsx
+++ b/frontend/src/components/eventCalendar/SubscribeToCalendarButton.tsx
@@ -111,8 +111,9 @@ export default function SubscribeToCalendarButton({
     }
   };
 
-  const googleCalendarUrl = feedUrl
-    ? `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedUrl)}`
+  const webcalFeedUrl = feedUrl ? feedUrl.replace(/^https?:\/\//, "webcal://") : "";
+  const googleCalendarUrl = webcalFeedUrl
+    ? `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(webcalFeedUrl)}`
     : "";
 
   return (


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme

## What and Why

Minor change for #2252 fixing the add to google calendar button. 
