### PR TITLE
Fix mini profile and org preview display

### DIFF
--- a/frontend/src/components/eventCalendar/SubscribeToCalendarButton.tsx
+++ b/frontend/src/components/eventCalendar/SubscribeToCalendarButton.tsx
@@ -111,8 +111,9 @@ export default function SubscribeToCalendarButton({
     }
   };
 
-  const googleCalendarUrl = feedUrl
-    ? `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedUrl)}`
+  const webcalFeedUrl = feedUrl ? feedUrl.replace(/^https?:\/\//, "webcal://") : "";
+  const googleCalendarUrl = webcalFeedUrl
+    ? `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(webcalFeedUrl)}`
     : "";
 
   return (

--- a/frontend/src/components/organization/MiniOrganizationPreview.tsx
+++ b/frontend/src/components/organization/MiniOrganizationPreview.tsx
@@ -46,11 +46,19 @@ const useStyles = makeStyles<Theme, { showBorder: boolean }>((theme) => ({
     wordBreak: "break-word",
   },
   inlineWrapper: {
-    display: "inline-block",
+    display: "inline-flex",
+    alignItems: "center",
+    verticalAlign: "middle",
   },
   boldOrgName: {
     fontSize: 18,
     fontWeight: 600,
+    display: "inline-block",
+  },
+  inlineBoldOrgName: {
+    fontSize: "inherit",
+    fontWeight: 600,
+    lineHeight: "inherit",
     display: "inline-block",
   },
 }));
@@ -125,7 +133,11 @@ function Content({ organization, size, onDelete, doNotShowName, inline }) {
               <Tooltip title={organization.name} placement="bottom">
                 <Typography
                   variant="body2"
-                  className={`${classes.boldOrgName} ${classes.tinyOrgName}`}
+                  className={
+                    inline
+                      ? `${classes.inlineBoldOrgName} ${classes.tinyOrgName}`
+                      : `${classes.boldOrgName} ${classes.tinyOrgName}`
+                  }
                 >
                   {organization.name}
                 </Typography>

--- a/frontend/src/components/profile/MiniProfilePreview.tsx
+++ b/frontend/src/components/profile/MiniProfilePreview.tsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles((theme) => {
     contentWrapper: {
       display: "inline-flex",
       alignItems: "center",
+      verticalAlign: "middle",
     },
     badge: {
       bottom: "20%",

--- a/frontend/src/components/project/ProjectContent.tsx
+++ b/frontend/src/components/project/ProjectContent.tsx
@@ -29,13 +29,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: "block",
     fontSize: 14,
   },
-  creator: (props) => ({
-    paddingTop: props.isPersonalProject && theme.spacing(0.25),
+  creator: {
     paddingLeft: theme.spacing(1),
     color: theme.palette.grey[800],
     cursor: "pointer",
     wordBreak: "break-word",
-  }),
+    "& h6": {
+      fontSize: "inherit",
+      fontWeight: 600,
+      lineHeight: "inherit",
+    },
+  },
   collaboratingOrganization: {
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),
@@ -185,7 +189,7 @@ export default function ProjectContent({
   onEventRegistrationUpdated,
   onMembersRefreshed,
 }) {
-  const classes = useStyles({ isPersonalProject: project.isPersonalProject });
+  const classes = useStyles({});
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale: locale, project: project });
   const [showFullDescription, setShowFullDescription] = useState(false);


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme

## What and Why

Minor CSS tweaks to address some layout issues. No functional changes. 

Addresses this alignment issue of the organisation/profile name:
<img width="829" height="185" alt="Screenshot 2026-09-01 at 12 59 16" src="https://github.com/user-attachments/assets/1c2e2b60-4709-4be1-8063-7a3c09c12905" />

Aligns it vertically and adjusts font-size and line-height to be the same. 
