### PR TITLE
Improve spacing on pages with sub hubs

### DIFF
--- a/frontend/src/components/browse/BrowseContentBase.tsx
+++ b/frontend/src/components/browse/BrowseContentBase.tsx
@@ -27,8 +27,11 @@ const useStyles = makeStyles((theme) => ({
   contentContainer: {
     paddingLeft: 24,
     paddingRight: 24,
-    paddingTop: theme.spacing(2),
+    paddingTop: theme.spacing(4),
     position: "relative",
+    [theme.breakpoints.down("md")]: {
+      paddingTop: theme.spacing(2),
+    },
   },
   tabContent: {
     marginTop: theme.spacing(2),

--- a/frontend/src/components/browse/BrowseContentBase.tsx
+++ b/frontend/src/components/browse/BrowseContentBase.tsx
@@ -27,11 +27,8 @@ const useStyles = makeStyles((theme) => ({
   contentContainer: {
     paddingLeft: 24,
     paddingRight: 24,
-    paddingTop: theme.spacing(4),
+    paddingTop: theme.spacing(2),
     position: "relative",
-    [theme.breakpoints.down("md")]: {
-      paddingTop: theme.spacing(2),
-    },
   },
   tabContent: {
     marginTop: theme.spacing(2),

--- a/frontend/src/components/hub/HubLinkButton.tsx
+++ b/frontend/src/components/hub/HubLinkButton.tsx
@@ -38,6 +38,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => {
       backgroundColor: "#EFF5F2",
       paddingTop: theme.spacing(3),
       paddingBottom: theme.spacing(1),
+      marginBottom: 0,
       borderRadius: theme.shape.borderRadius,
     },
     iconContainer: {

--- a/frontend/src/components/hub/HubPageLayout.tsx
+++ b/frontend/src/components/hub/HubPageLayout.tsx
@@ -31,7 +31,6 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: 24,
     paddingRight: 24,
     marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(1),
     gap: theme.spacing(1),
   },
   linkedHubsContainerMobile: {
@@ -39,8 +38,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "row",
     overflowX: "auto",
     gap: theme.spacing(2),
-    padding: theme.spacing(2, 0),
-    marginBottom: theme.spacing(1),
+    padding: theme.spacing(2, 0, 0),
   },
   subHubInfoText: {
     fontStyle: "italic",

--- a/frontend/src/components/hub/HubPageLayout.tsx
+++ b/frontend/src/components/hub/HubPageLayout.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: 24,
     paddingRight: 24,
     marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacing(1),
     gap: theme.spacing(1),
   },
   linkedHubsContainerMobile: {
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
     overflowX: "auto",
     gap: theme.spacing(2),
     padding: theme.spacing(2, 0),
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacing(1),
   },
   subHubInfoText: {
     fontStyle: "italic",


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme

## What and Why

Minor layout change to adjust styling when we have sub-hub navigation. No functional change. 
